### PR TITLE
Add dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,18 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "v0.2"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: ":seedling:"
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "v0.2"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: ":seedling:"
+    open-pull-requests-limit: 20

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    target-branch: "v0.2"
     schedule:
       interval: "weekly"
     commit-message:
@@ -11,7 +10,6 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "v0.2"
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
Allow Dependabot to open pull requests automatically to keep the dependencies up-to-date when new versions are available.