### PR TITLE
Fix allowed endpoint related to Azure Blob Storage

### DIFF
--- a/.github/workflows/lint.js.yml
+++ b/.github/workflows/lint.js.yml
@@ -31,7 +31,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
-            kv4gacprodeus2file3.blob.core.windows.net:443
+            *.blob.core.windows.net:443
             github.com:443
             nodejs.org:443
             registry.npmjs.org:443

--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -32,7 +32,7 @@ jobs:
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
             github.com:443
-            kv4gacprodeus2file3.blob.core.windows.net:443
+            *.blob.core.windows.net:443
             nodejs.org:443
             registry.npmjs.org:443
       - uses: actions/checkout@d171c3b028d844f2bf14e9fdec0c58114451e4bf


### PR DESCRIPTION
The allowed endpoint related to Azure Blob Storage needs to be updated because there are cases where the host changes.

For example:
![image](https://user-images.githubusercontent.com/39246879/187324400-291f11ef-8828-4fbf-8c8f-f71f490126c7.png)


More info: https://github.com/MicrosoftDocs/visualstudio-docs/issues/5376#issuecomment-636168257