### PR TITLE
Revert "Fix allowed endpoint related to Azure Blob Storage"

### DIFF
--- a/.github/workflows/lint.js.yml
+++ b/.github/workflows/lint.js.yml
@@ -31,7 +31,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
-            *.blob.core.windows.net:443
+            kv4gacprodeus2file3.blob.core.windows.net:443
             github.com:443
             nodejs.org:443
             registry.npmjs.org:443

--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -32,7 +32,7 @@ jobs:
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
             github.com:443
-            *.blob.core.windows.net:443
+            kv4gacprodeus2file3.blob.core.windows.net:443
             nodejs.org:443
             registry.npmjs.org:443
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b


### PR DESCRIPTION
Reverts kommitters/editorjs-toggle-block#102

Wildcard domains is not supported by `harden-runner`. In addition, the Azure Storage endpoint is used for cache, so that it is repo specific, and we shouldn't use a wildcard domain but a specific one like before.

https://github.com/step-security/harden-runner/issues/161#issuecomment-1234589820