### PR TITLE
Update scorecard-action to v2.0.2 to enable scorecard badge

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -3,7 +3,7 @@ on:
   # Only the default branch is supported.
   branch_protection_rule:
   schedule:
-    - cron: '25 6 * * 3'
+    - cron: '0 0 * * 0'
   push:
     branches: [ "main" ]
 
@@ -17,17 +17,17 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
-      # Used to receive a badge. (Upcoming feature)
+      # Used to receive a badge.
       id-token: write
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.0
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@08dd0cebb088ac0fd6364339b1b3b68b75041ea8 # v2.0.0-alpha.2
+        uses: ossf/scorecard-action@68bf5b3327e4fd443d2add8ab122280547b4a16d # v2.0.2
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
This merge in `main` does not require a release. It is only to show the Scorecard badge properly.