### PR TITLE
Prepare release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.8 (13.01.2023)
+
+* Update all dependencies.
+* Block egress traffic in GitHub Actions.
+* Add stability badge in README.
+* Delete `yarn.lock` file to keep a single package manager.
+
 ## 0.3.7 (28.12.2022)
 
 * Add Renovate as dependency update tool.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editorjs-toggle-block",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Toogle block tool for Editor.js",
   "main": "./dist/bundle.js",
   "scripts": {


### PR DESCRIPTION
## 0.3.8 (13.01.2023)

* Update all dependencies.
* Block egress traffic in GitHub Actions.
* Add stability badge in README.
* Delete `yarn.lock` file to keep a single package manager.