### PR TITLE
Reduce package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+.idea/
+src/
+test/
+assets/
+dev/
+.eslintrc.js
+babel.config.json
+webpack.config.js
+yarn.lock


### PR DESCRIPTION
## Description:

The library has a size of 1.21 MB, which, for a library is a lot. We must find a way to reduce this, possibly due to the GIF used in the README.

![image](https://user-images.githubusercontent.com/50219561/232823926-7d9b9f44-e029-4a57-b197-2d0b7ead640f.png)

## Solution

It was missing a `.npmignore` file in order to avoid uploading files that are not necessary for the npm package and were increasing the size of the final package.

New package size:
![image](https://user-images.githubusercontent.com/50219561/232824211-1132ccc7-493f-4f93-8ace-c47ecad9a00a.png)
